### PR TITLE
bundle of some smaller changes

### DIFF
--- a/app_template/Makefile
+++ b/app_template/Makefile
@@ -6,20 +6,20 @@ ifndef SDK_DIR
 $(error You need to define the SDK_DIR environment variable, and point it to the sdk/ folder)
 endif
 
-AS:=sh4-elf-as
+AS:=sh4aeb-elf-gcc
 AS_FLAGS:=
 
-CC:=sh4-elf-gcc
-CC_FLAGS:=-ffreestanding -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CC:=sh4aeb-elf-gcc
+CC_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-CXX:=sh4-elf-g++
-CXX_FLAGS:=-ffreestanding -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/ -m4a-nofpu
+CXX:=sh4aeb-elf-g++
+CXX_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/ -m4a-nofpu
 
-LD:=sh4-elf-ld
-LD_FLAGS:=-nostdlib --no-undefined
+LD:=sh4aeb-elf-g++
+LD_FLAGS:=-nostartfiles --specs=nosys.specs -Wno-undef -Wl,--gc-sections -L$(SDK_DIR)
 
-READELF:=sh4-elf-readelf
-OBJCOPY:=sh4-elf-objcopy
+READELF:=sh4aeb-elf-readelf
+OBJCOPY:=sh4aeb-elf-objcopy
 
 AS_SOURCES:=$(wildcard *.s)
 CC_SOURCES:=$(wildcard *.c)
@@ -38,24 +38,24 @@ all: $(APP_ELF) $(APP_BIN) Makefile
 clean:
 	rm -f $(OBJECTS) $(APP_ELF) $(APP_BIN)
 
-$(APP_ELF): $(OBJECTS) $(SDK_DIR)/sdk.o linker_hhk.ld
-	$(LD) -T linker_hhk.ld -o $@ $(LD_FLAGS) $(OBJECTS) $(SDK_DIR)/sdk.o
+$(APP_ELF): $(OBJECTS) $(SDK_DIR)/libsdk.a linker_hhk.ld
+	$(LD) -T linker_hhk.ld -o $@ $(LD_FLAGS) $(OBJECTS) -lsdk
 	$(OBJCOPY) --set-section-flags .hollyhock_name=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_description=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_author=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_version=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 
-$(APP_BIN): $(OBJECTS) $(SDK_DIR)/sdk.o linker_bin.ld
-	$(LD) --oformat binary -T linker_bin.ld -o $@ $(LD_FLAGS) $(OBJECTS) $(SDK_DIR)/sdk.o
+$(APP_BIN): $(OBJECTS) $(SDK_DIR)/libsdk.a linker_bin.ld
+	$(LD) -T linker_bin.ld -o $@ $(LD_FLAGS) $(OBJECTS) -lsdk
 
-# We're not actually building sdk.o, just telling the user they need to do it
+# We're not actually building libsdk.a, just telling the user they need to do it
 # themselves. Just using the target to trigger an error when the file is
 # required but does not exist.
-$(SDK_DIR)/sdk.o:
+$(SDK_DIR)/libsdk.a:
 	$(error You need to build the SDK before using it. Run make in the SDK directory, and check the README.md in the SDK directory for more information)
 
 %.o: %.s
-	$(AS) $< -o $@ $(AS_FLAGS)
+	$(AS) -c $< -o $@ $(AS_FLAGS)
 
 %.o: %.c
 	$(CC) -c $< -o $@ $(CC_FLAGS)

--- a/app_template/linker_bin.ld
+++ b/app_template/linker_bin.ld
@@ -1,3 +1,4 @@
+OUTPUT_FORMAT(binary);
 ENTRY(_main);
 
 SECTIONS {

--- a/demos/breakpoint_util/Makefile
+++ b/demos/breakpoint_util/Makefile
@@ -4,20 +4,20 @@ ifndef SDK_DIR
 $(error You need to define the SDK_DIR environment variable, and point it to the sdk/ folder)
 endif
 
-AS:=sh4-elf-as
+AS:=sh4aeb-elf-gcc
 AS_FLAGS:=
 
-CC:=sh4-elf-gcc
-CC_FLAGS:=-ffreestanding -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CC:=sh4aeb-elf-gcc
+CC_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-CXX:=sh4-elf-g++
-CXX_FLAGS:=-ffreestanding -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CXX:=sh4aeb-elf-g++
+CXX_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-LD:=sh4-elf-ld
-LD_FLAGS:=-nostdlib --no-undefined
+LD:=sh4aeb-elf-g++
+LD_FLAGS:=-nostartfiles --specs=nosys.specs -Wno-undef -Wl,--gc-sections -L$(SDK_DIR)
 
-READELF:=sh4-elf-readelf
-OBJCOPY:=sh4-elf-objcopy
+READELF:=sh4aeb-elf-readelf
+OBJCOPY:=sh4aeb-elf-objcopy
 
 AS_SOURCES:=$(wildcard *.s)
 CC_SOURCES:=$(wildcard *.c)
@@ -31,21 +31,21 @@ all: $(APP_ELF) Makefile
 clean:
 	rm -f $(OBJECTS) $(APP_ELF)
 
-$(APP_ELF): $(OBJECTS) $(SDK_DIR)/sdk.o linker.ld
-	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) $(SDK_DIR)/sdk.o
+$(APP_ELF): $(OBJECTS) $(SDK_DIR)/libsdk.a linker.ld
+	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) -lsdk
 	$(OBJCOPY) --set-section-flags .hollyhock_name=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_description=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_author=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_version=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 
-# We're not actually building sdk.o, just telling the user they need to do it
+# We're not actually building libsdk.a, just telling the user they need to do it
 # themselves. Just using the target to trigger an error when the file is
 # required but does not exist.
-$(SDK_DIR)/sdk.o:
+$(SDK_DIR)/libsdk.a:
 	$(error You need to build the SDK before using it. Run make in the SDK directory, and check the README.md in the SDK directory for more information)
 
 %.o: %.s
-	$(AS) $< -o $@ $(AS_FLAGS)
+	$(AS) -c $< -o $@ $(AS_FLAGS)
 
 %.o: %.c
 	$(CC) $< -o $@ $(CC_FLAGS)

--- a/demos/demo_gui/Makefile
+++ b/demos/demo_gui/Makefile
@@ -4,20 +4,20 @@ ifndef SDK_DIR
 $(error You need to define the SDK_DIR environment variable, and point it to the sdk/ folder)
 endif
 
-AS:=sh4-elf-as
+AS:=sh4aeb-elf-gcc
 AS_FLAGS:=
 
-CC:=sh4-elf-gcc
-CC_FLAGS:=-ffreestanding -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CC:=sh4aeb-elf-gcc
+CC_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-CXX:=sh4-elf-g++
-CXX_FLAGS:=-ffreestanding -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CXX:=sh4aeb-elf-g++
+CXX_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-LD:=sh4-elf-ld
-LD_FLAGS:=-nostdlib --no-undefined
+LD:=sh4aeb-elf-g++
+LD_FLAGS:=-nostartfiles --specs=nosys.specs -Wno-undef -Wl,--gc-sections -L$(SDK_DIR)
 
-READELF:=sh4-elf-readelf
-OBJCOPY:=sh4-elf-objcopy
+READELF:=sh4aeb-elf-readelf
+OBJCOPY:=sh4aeb-elf-objcopy
 
 AS_SOURCES:=$(wildcard *.s)
 CC_SOURCES:=$(wildcard *.c)
@@ -31,21 +31,21 @@ all: $(APP_ELF) Makefile
 clean:
 	rm -f $(OBJECTS) $(APP_ELF)
 
-$(APP_ELF): $(OBJECTS) $(SDK_DIR)/sdk.o linker.ld
-	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) $(SDK_DIR)/sdk.o
+$(APP_ELF): $(OBJECTS) $(SDK_DIR)/libsdk.a linker.ld
+	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) -lsdk
 	$(OBJCOPY) --set-section-flags .hollyhock_name=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_description=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_author=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_version=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 
-# We're not actually building sdk.o, just telling the user they need to do it
+# We're not actually building libsdk.a, just telling the user they need to do it
 # themselves. Just using the target to trigger an error when the file is
 # required but does not exist.
-$(SDK_DIR)/sdk.o:
+$(SDK_DIR)/libsdk.a:
 	$(error You need to build the SDK before using it. Run make in the SDK directory, and check the README.md in the SDK directory for more information)
 
 %.o: %.s
-	$(AS) $< -o $@ $(AS_FLAGS)
+	$(AS) -c $< -o $@ $(AS_FLAGS)
 
 %.o: %.c
 	$(CC) $< -o $@ $(CC_FLAGS)

--- a/demos/input_key/Makefile
+++ b/demos/input_key/Makefile
@@ -4,20 +4,20 @@ ifndef SDK_DIR
 $(error You need to define the SDK_DIR environment variable, and point it to the sdk/ folder)
 endif
 
-AS:=sh4-elf-as
+AS:=sh4aeb-elf-gcc
 AS_FLAGS:=
 
-CC:=sh4-elf-gcc
-CC_FLAGS:=-ffreestanding -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CC:=sh4aeb-elf-gcc
+CC_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-CXX:=sh4-elf-g++
-CXX_FLAGS:=-ffreestanding -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CXX:=sh4aeb-elf-g++
+CXX_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fdata-sections -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-LD:=sh4-elf-ld
-LD_FLAGS:=-nostdlib --no-undefined
+LD:=sh4aeb-elf-g++
+LD_FLAGS:=-nostartfiles --specs=nosys.specs -Wno-undef -Wl,--gc-sections -L$(SDK_DIR)
 
-READELF:=sh4-elf-readelf
-OBJCOPY:=sh4-elf-objcopy
+READELF:=sh4aeb-elf-readelf
+OBJCOPY:=sh4aeb-elf-objcopy
 
 AS_SOURCES:=$(wildcard *.s)
 CC_SOURCES:=$(wildcard *.c)
@@ -31,21 +31,21 @@ all: $(APP_ELF) Makefile
 clean:
 	rm -f $(OBJECTS) $(APP_ELF)
 
-$(APP_ELF): $(OBJECTS) $(SDK_DIR)/sdk.o linker.ld
-	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) $(SDK_DIR)/sdk.o
+$(APP_ELF): $(OBJECTS) $(SDK_DIR)/libsdk.a linker.ld
+	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) -lsdk
 	$(OBJCOPY) --set-section-flags .hollyhock_name=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_description=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_author=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_version=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 
-# We're not actually building sdk.o, just telling the user they need to do it
+# We're not actually building libsdk.a, just telling the user they need to do it
 # themselves. Just using the target to trigger an error when the file is
 # required but does not exist.
-$(SDK_DIR)/sdk.o:
+$(SDK_DIR)/libsdk.a:
 	$(error You need to build the SDK before using it. Run make in the SDK directory, and check the README.md in the SDK directory for more information)
 
 %.o: %.s
-	$(AS) $< -o $@ $(AS_FLAGS)
+	$(AS) -c $< -o $@ $(AS_FLAGS)
 
 %.o: %.c
 	$(CC) $< -o $@ $(CC_FLAGS)

--- a/demos/input_test/Makefile
+++ b/demos/input_test/Makefile
@@ -4,20 +4,20 @@ ifndef SDK_DIR
 $(error You need to define the SDK_DIR environment variable, and point it to the sdk/ folder)
 endif
 
-AS:=sh4-elf-as
+AS:=sh4aeb-elf-gcc
 AS_FLAGS:=
 
-CC:=sh4-elf-gcc
-CC_FLAGS:=-ffreestanding -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CC:=sh4aeb-elf-gcc
+CC_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-CXX:=sh4-elf-g++
-CXX_FLAGS:=-ffreestanding -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CXX:=sh4aeb-elf-g++
+CXX_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fdata-sections -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-LD:=sh4-elf-ld
-LD_FLAGS:=-nostdlib --no-undefined
+LD:=sh4aeb-elf-g++
+LD_FLAGS:=-nostartfiles --specs=nosys.specs -Wno-undef -Wl,--gc-sections -L$(SDK_DIR)
 
-READELF:=sh4-elf-readelf
-OBJCOPY:=sh4-elf-objcopy
+READELF:=sh4aeb-elf-readelf
+OBJCOPY:=sh4aeb-elf-objcopy
 
 AS_SOURCES:=$(wildcard *.s)
 CC_SOURCES:=$(wildcard *.c)
@@ -31,21 +31,21 @@ all: $(APP_ELF) Makefile
 clean:
 	rm -f $(OBJECTS) $(APP_ELF)
 
-$(APP_ELF): $(OBJECTS) $(SDK_DIR)/sdk.o linker.ld
-	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) $(SDK_DIR)/sdk.o
+$(APP_ELF): $(OBJECTS) $(SDK_DIR)/libsdk.a linker.ld
+	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) -lsdk
 	$(OBJCOPY) --set-section-flags .hollyhock_name=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_description=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_author=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_version=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 
-# We're not actually building sdk.o, just telling the user they need to do it
+# We're not actually building libsdk.a, just telling the user they need to do it
 # themselves. Just using the target to trigger an error when the file is
 # required but does not exist.
-$(SDK_DIR)/sdk.o:
+$(SDK_DIR)/libsdk.a:
 	$(error You need to build the SDK before using it. Run make in the SDK directory, and check the README.md in the SDK directory for more information)
 
 %.o: %.s
-	$(AS) $< -o $@ $(AS_FLAGS)
+	$(AS) -c $< -o $@ $(AS_FLAGS)
 
 %.o: %.c
 	$(CC) $< -o $@ $(CC_FLAGS)

--- a/demos/random_circles/Makefile
+++ b/demos/random_circles/Makefile
@@ -4,20 +4,20 @@ ifndef SDK_DIR
 $(error You need to define the SDK_DIR environment variable, and point it to the sdk/ folder)
 endif
 
-AS:=sh4-elf-as
+AS:=sh4aeb-elf-gcc
 AS_FLAGS:=
 
-CC:=sh4-elf-gcc
-CC_FLAGS:=-ffreestanding -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CC:=sh4aeb-elf-gcc
+CC_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-CXX:=sh4-elf-g++
-CXX_FLAGS:=-ffreestanding -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CXX:=sh4aeb-elf-g++
+CXX_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-LD:=sh4-elf-ld
-LD_FLAGS:=-nostdlib --no-undefined
+LD:=sh4aeb-elf-g++
+LD_FLAGS:=-nostartfiles --specs=nosys.specs -Wno-undef -Wl,--gc-sections -L$(SDK_DIR)
 
-READELF:=sh4-elf-readelf
-OBJCOPY:=sh4-elf-objcopy
+READELF:=sh4aeb-elf-readelf
+OBJCOPY:=sh4aeb-elf-objcopy
 
 AS_SOURCES:=$(wildcard *.s)
 CC_SOURCES:=$(wildcard *.c)
@@ -31,21 +31,21 @@ all: $(APP_ELF) Makefile
 clean:
 	rm -f $(OBJECTS) $(APP_ELF)
 
-$(APP_ELF): $(OBJECTS) $(SDK_DIR)/sdk.o linker.ld
-	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) $(SDK_DIR)/sdk.o
+$(APP_ELF): $(OBJECTS) $(SDK_DIR)/libsdk.a linker.ld
+	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) -lsdk
 	$(OBJCOPY) --set-section-flags .hollyhock_name=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_description=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_author=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_version=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 
-# We're not actually building sdk.o, just telling the user they need to do it
+# We're not actually building libsdk.a, just telling the user they need to do it
 # themselves. Just using the target to trigger an error when the file is
 # required but does not exist.
-$(SDK_DIR)/sdk.o:
+$(SDK_DIR)/libsdk.a:
 	$(error You need to build the SDK before using it. Run make in the SDK directory, and check the README.md in the SDK directory for more information)
 
 %.o: %.s
-	$(AS) $< -o $@ $(AS_FLAGS)
+	$(AS) -c $< -o $@ $(AS_FLAGS)
 
 %.o: %.c
 	$(CC) $< -o $@ $(CC_FLAGS)

--- a/demos/snake/Makefile
+++ b/demos/snake/Makefile
@@ -4,20 +4,20 @@ ifndef SDK_DIR
 $(error You need to define the SDK_DIR environment variable, and point it to the sdk/ folder)
 endif
 
-AS:=sh4-elf-as
+AS:=sh4aeb-elf-gcc
 AS_FLAGS:=
 
-CC:=sh4-elf-gcc
-CC_FLAGS:=-ffreestanding -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CC:=sh4aeb-elf-gcc
+CC_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-CXX:=sh4-elf-g++
-CXX_FLAGS:=-ffreestanding -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CXX:=sh4aeb-elf-g++
+CXX_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-LD:=sh4-elf-ld
-LD_FLAGS:=-nostdlib --no-undefined
+LD:=sh4aeb-elf-g++
+LD_FLAGS:=-nostartfiles --specs=nosys.specs -Wno-undef -Wl,--gc-sections -L$(SDK_DIR)
 
-READELF:=sh4-elf-readelf
-OBJCOPY:=sh4-elf-objcopy
+READELF:=sh4aeb-elf-readelf
+OBJCOPY:=sh4aeb-elf-objcopy
 
 AS_SOURCES:=$(wildcard *.s)
 CC_SOURCES:=$(wildcard *.c)
@@ -31,21 +31,21 @@ all: $(APP_ELF) Makefile
 clean:
 	rm -f $(OBJECTS) $(APP_ELF)
 
-$(APP_ELF): $(OBJECTS) $(SDK_DIR)/sdk.o linker.ld
-	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) $(SDK_DIR)/sdk.o
+$(APP_ELF): $(OBJECTS) $(SDK_DIR)/libsdk.a linker.ld
+	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) -lsdk
 	$(OBJCOPY) --set-section-flags .hollyhock_name=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_description=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_author=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_version=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 
-# We're not actually building sdk.o, just telling the user they need to do it
+# We're not actually building libsdk.a, just telling the user they need to do it
 # themselves. Just using the target to trigger an error when the file is
 # required but does not exist.
-$(SDK_DIR)/sdk.o:
+$(SDK_DIR)/libsdk.a:
 	$(error You need to build the SDK before using it. Run make in the SDK directory, and check the README.md in the SDK directory for more information)
 
 %.o: %.s
-	$(AS) $< -o $@ $(AS_FLAGS)
+	$(AS) -c $< -o $@ $(AS_FLAGS)
 
 %.o: %.c
 	$(CC) $< -o $@ $(CC_FLAGS)

--- a/demos/tetris/Makefile
+++ b/demos/tetris/Makefile
@@ -4,20 +4,20 @@ ifndef SDK_DIR
 $(error You need to define the SDK_DIR environment variable, and point it to the sdk/ folder)
 endif
 
-AS:=sh4-elf-as
+AS:=sh4aeb-elf-gcc
 AS_FLAGS:=
 
-CC:=sh4-elf-gcc
-CC_FLAGS:=-ffreestanding -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CC:=sh4aeb-elf-gcc
+CC_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-CXX:=sh4-elf-g++
-CXX_FLAGS:=-ffreestanding -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CXX:=sh4aeb-elf-g++
+CXX_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-LD:=sh4-elf-ld
-LD_FLAGS:=-nostdlib --no-undefined
+LD:=sh4aeb-elf-g++
+LD_FLAGS:=-nostartfiles --specs=nosys.specs -Wno-undef -Wl,--gc-sections -L$(SDK_DIR)
 
-READELF:=sh4-elf-readelf
-OBJCOPY:=sh4-elf-objcopy
+READELF:=sh4aeb-elf-readelf
+OBJCOPY:=sh4aeb-elf-objcopy
 
 AS_SOURCES:=$(wildcard *.s)
 CC_SOURCES:=$(wildcard *.c)
@@ -31,21 +31,21 @@ all: $(APP_ELF) Makefile
 clean:
 	rm -f $(OBJECTS) $(APP_ELF)
 
-$(APP_ELF): $(OBJECTS) $(SDK_DIR)/sdk.o linker.ld
-	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) $(SDK_DIR)/sdk.o
+$(APP_ELF): $(OBJECTS) $(SDK_DIR)/libsdk.a linker.ld
+	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) -lsdk
 	$(OBJCOPY) --set-section-flags .hollyhock_name=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_description=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_author=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 	$(OBJCOPY) --set-section-flags .hollyhock_version=contents,strings,readonly $(APP_ELF) $(APP_ELF)
 
-# We're not actually building sdk.o, just telling the user they need to do it
+# We're not actually building libsdk.a, just telling the user they need to do it
 # themselves. Just using the target to trigger an error when the file is
 # required but does not exist.
-$(SDK_DIR)/sdk.o:
+$(SDK_DIR)/libsdk.a:
 	$(error You need to build the SDK before using it. Run make in the SDK directory, and check the README.md in the SDK directory for more information)
 
 %.o: %.s
-	$(AS) $< -o $@ $(AS_FLAGS)
+	$(AS) -c $< -o $@ $(AS_FLAGS)
 
 %.o: %.c
 	$(CC) $< -o $@ $(CC_FLAGS)

--- a/doc/user/developing.md
+++ b/doc/user/developing.md
@@ -88,8 +88,8 @@ Congratulations! You can now utilize standard C functions in your fx-CP400 proje
 If you also want newlib to create the arithmetic subroutines, you will need to modify a few more things in your Makefile.
 
 ```make
-LD:=sh4-elf-gcc # Change the linker to gcc instead of ld
-LD_FLAGS:=-nostartfiles -m4-nofpu -Wno-undef -L$(SDK_DIR)/newlib/sh-elf/lib # Change your LD_FLAGS to this (remove -nostdlib and --no-undefined)
+LD:=sh4aeb-elf-g++ # Change the linker to gcc instead of ld
+LD_FLAGS:=-nostartfiles ---specs=nosys.specs -m4a-nofpu -Wno-undef -L$(SDK_DIR)/newlib/sh-elf/lib # Change your LD_FLAGS to this (remove --no-undefined)
 
 # For the APP_BIN target rule, change the line
 $(LD) --oformat=binary -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) $(SDK_DIR)/sdk.o

--- a/doc/user/patching.md
+++ b/doc/user/patching.md
@@ -44,7 +44,7 @@ make
 sudo make install
 ```
 
-You'll now have tools such as `sh4-elf-as` and `sh4-elf-objcopy` available.
+You'll now have tools such as `sh4aeb-elf-objcopy` available.
 
 Now, download the most recent stable version of the GCC source code from the [GCC website](https://gnu.org/software/gcc/). Extract the compressed file containing the source code into a directory, and `cd` into the newly created directory. Then, run these commands inside that directory. Be warned - the `make` commands may take a long time, depending on your system, and the `contrib/download_prerequisites` script will download about 30 MB of archives. (SnailMath is using version 10.2.0)
 
@@ -60,7 +60,7 @@ sudo make install-target-libgcc
 ```
 (Note: The `--with-multilib-list=m4-nofpu` flag is needed because the cpu doesn't have an fpu)
 
-You’ll now have `sh4-elf-gcc` and `sh4-elf-g++` available for your usage.
+You’ll now have `sh4aeb-elf-g++` available for your usage.
 
 _I would recommend adding `export PATH="$PATH:$HOME/opt/cross/bin"` to the file .bashrc in the home directory to add the path automatically after every login._
 _I would recommend adding `export SDK_DIR="PATH-TO/hollyhock-2/sdk"` to the file .bashrc in the home directory to export the sdk dir automatically after every login._

--- a/launcher/Makefile
+++ b/launcher/Makefile
@@ -2,20 +2,20 @@ ifndef SDK_DIR
 $(error You need to define the SDK_DIR environment variable, and point it to the sdk/ folder)
 endif
 
-AS:=sh4-elf-as
+AS:=sh4aeb-elf-gcc
 AS_FLAGS:=
 
 CC:=sh4-elf0-gcc
-CC_FLAGS:=-ffreestanding -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CC_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-CXX:=sh4-elf-g++
-CXX_FLAGS:=-ffreestanding -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -O2 -I $(SDK_DIR)/include/
+CXX:=sh4aeb-elf-g++
+CXX_FLAGS:=-ffreestanding -flto -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti -fshort-wchar -Wall -Wextra -Os -I $(SDK_DIR)/include/
 
-LD:=sh4-elf-ld
-LD_FLAGS:=-nostdlib --no-undefined
+LD:=sh4aeb-elf-g++
+LD_FLAGS:=-nolibc -nostartfiles -Wno-undef -Wl,--gc-sections -L$(SDK_DIR)
 
-READELF:=sh4-elf-readelf
-OBJCOPY:=sh4-elf-objcopy
+READELF:=sh4aeb-elf-readelf
+OBJCOPY:=sh4aeb-elf-objcopy
 
 AS_SOURCES:=$(wildcard *.s)
 CC_SOURCES:=$(wildcard *.c)
@@ -27,20 +27,20 @@ all: run.bin Makefile
 clean:
 	rm -f $(OBJECTS) run.bin
 
-run.bin: $(OBJECTS) $(SDK_DIR)/sdk.o linker.ld
-	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) $(SDK_DIR)/sdk.o
+run.bin: $(OBJECTS) $(SDK_DIR)/libsdk.a linker.ld
+	$(LD) -T linker.ld -o $@ $(LD_FLAGS) $(OBJECTS) -lsdk
 
-# We're not actually building sdk.o, just telling the user they need to do it
+# We're not actually building libsdk.a, just telling the user they need to do it
 # themselves. Just using the target to trigger an error when the file is
 # required but does not exist.
-$(SDK_DIR)/sdk.o:
+$(SDK_DIR)/libsdk.a:
 	$(error You need to build the SDK before using it. Run make in the SDK directory, and check the README.md in the SDK directory for more information)
 
 %.o: %.s
-	$(AS) $< -o $@ $(AS_FLAGS)
+	$(AS) -c $< -o $@ $(AS_FLAGS)
 
 %.o: %.c
-	$(CC) $< -o $@ $(CC_FLAGS)
+	$(CC) -c $< -o $@ $(CC_FLAGS)
 
 # Break the build if global constructors are present:
 # Read the sections from the object file (with readelf -S) and look for any

--- a/patches/file_loader/Makefile
+++ b/patches/file_loader/Makefile
@@ -1,9 +1,9 @@
 ADDR:=80128018
 
-AS:=sh4-elf-as
+AS:=sh4aeb-elf-gcc
 AS_FLAGS:=
 
-OBJCOPY:=sh4-elf-objcopy
+OBJCOPY:=sh4aeb-elf-objcopy
 OBJCOPY_FLAGS:=-O binary
 
 all: mod.part.txt Makefile
@@ -22,6 +22,6 @@ file_loader.bin: file_loader.o
 	$(OBJCOPY) $(OBJCOPY_FLAGS) file_loader.o file_loader.bin
 
 file_loader.o: file_loader.s
-	$(AS) $< -o $@ $(AS_FLAGS)
+	$(AS) -c $< -o $@ $(AS_FLAGS)
 
 .PHONY: all clean

--- a/sdk/.gitignore
+++ b/sdk/.gitignore
@@ -1,6 +1,6 @@
 # Compiled files
 *.o
-*.bin
+*.a
 
 # Doxygen output
 doc/

--- a/sdk/Makefile
+++ b/sdk/Makefile
@@ -1,36 +1,40 @@
 DOXYGEN=doxygen
 
-AS:=sh4-elf-as
+AS:=sh4aeb-elf-gcc
 AS_FLAGS:=
 
-CC:=sh4-elf-g++
-CC_FLAGS:=-ffreestanding -fno-exceptions -fno-rtti -m4-nofpu -Wall -Wextra -O2 -I include/
+CC:=sh4aeb-elf-g++
 
-# -r flag so the sdk.o file can be linked with the user's application object
-# files: generates a relocatable object file
-LD:=sh4-elf-ld
-LD_FLAGS:=-nostdlib -r
+CC_FLAGS:=-ffreestanding -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti -m4a-nofpu -Wall -Wextra -Os -I include/
+
+AR:=sh4aeb-elf-ar
+AR_FLAGS:=src
 
 AS_SOURCES:=$(wildcard *.s) $(wildcard **/*.s) $(wildcard **/**/*.s)
 CC_SOURCES:=$(wildcard *.cpp) $(wildcard **/*.cpp) $(wildcard **/**/*.cpp)
 OBJECTS:=$(AS_SOURCES:.s=.o) $(CC_SOURCES:.cpp=.o)
 
-all: sdk.o Makefile
+all: libsdk.a sdk.o Makefile
 
 docs:
 	$(DOXYGEN)
 
 clean:
-	rm -f $(OBJECTS) sdk.o
+	rm -f $(OBJECTS) libsdk.a sdk.o
 
 clean_docs:
 	rm -rf doc/
 
-sdk.o: $(OBJECTS)
-	$(LD) -o $@ $(LD_FLAGS) $(OBJECTS)
+libsdk.a: $(OBJECTS)
+
+lib%.a:
+	$(AR) $(AR_FLAGS) $@ $^
+
+%.o: lib%.a
+	ln -s $< $@
 
 %.o: %.s
-	$(AS) $< -o $@ $(AS_FLAGS)
+	$(AS) -c $< -o $@ $(AS_FLAGS)
 
 %.o: %.cpp
 	$(CC) -c $< -o $@ $(CC_FLAGS)


### PR DESCRIPTION
- use LTO
- use function sections and --gc-sections
- change triplet
- make sdk a lib
- use gcc as as
- use g++ as ld
- optimize for size
- import more libraries
- optimize for SH4A (no fpu)

this expects a newlib sysroot, with the exeption of the sdk and launcher.